### PR TITLE
use NodeNext modules by default

### DIFF
--- a/packages/ts-config/package.json
+++ b/packages/ts-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintlify/ts-config",
-  "version": "1.0.9",
+  "version": "2.0.0",
   "description": "Mintlify shared ts config",
   "author": "Mintlify, Inc.",
   "homepage": "https://mintlify.com/",

--- a/packages/ts-config/tsconfig.json
+++ b/packages/ts-config/tsconfig.json
@@ -1,14 +1,11 @@
 {
   "extends": "@tsconfig/recommended", // https://github.com/tsconfig/bases/blob/main/bases/recommended.json
   "compilerOptions": {
-    "target": "ES5", // ES2019
+    "module": "NodeNext",
     "allowJs": true,
-    "module": "CommonJS",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "incremental": true,
-    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true
   }
 }


### PR DESCRIPTION
We've now converted every package (except @mintlify/http-client) in mint to an ESModule. We've been running into bugs due to missing `.js` extensions, since `moduleResolution` is not set. From typescript website:

[module resolution strategies](https://www.typescriptlang.org/docs/handbook/module-resolution.html#module-resolution-strategies)
> If not specified, the default is `Node` for --module commonjs, and `Classic` otherwise

[`"moduleResolution": "Classic"`](https://www.typescriptlang.org/tsconfig#moduleResolution)
> 'classic' was used in TypeScript before the release of 1.6. classic should not be used.

`"module": "NodeNext"` is now recommended by typescript:

[`module`](https://www.typescriptlang.org/tsconfig#module)
> You very likely want "nodenext" for modern node projects.


This also removes a few redundant settings that are already specified in [`@tsconfig/recommended`](https://github.com/tsconfig/bases/blob/main/bases/recommended.json)

Bumping to v2 because moving from commonjs to esm is a breaking (and big) change