### PR TITLE
add noUncheckedIndexedAccess to tsconfig

### DIFF
--- a/packages/ts-config/package.json
+++ b/packages/ts-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintlify/ts-config",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Mintlify shared ts config",
   "author": "Mintlify, Inc.",
   "homepage": "https://mintlify.com/",

--- a/packages/ts-config/tsconfig.json
+++ b/packages/ts-config/tsconfig.json
@@ -6,6 +6,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "incremental": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "noUncheckedIndexedAccess": true
   }
 }


### PR DESCRIPTION
By default, TS will allow you to use any string to index into an object indexed with `string`. Pretty crazy that it allows this by default

before:
<img width="366" alt="Screenshot 2023-11-03 at 8 27 00 PM" src="https://github.com/mintlify/config/assets/63772591/f86b79d4-f922-4d62-809f-1549b48c8139">

after:
<img width="433" alt="Screenshot 2023-11-03 at 8 26 43 PM" src="https://github.com/mintlify/config/assets/63772591/a18d7821-3da5-47a2-b956-fbae665769bf">
