### PR TITLE
Hahnbee/bump prettier in eslint configs

### DIFF
--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -24,7 +24,7 @@
     "@typescript-eslint/parser": "6.x",
     "eslint": "8.x",
     "eslint-config-next": "13.x",
-    "eslint-config-prettier": "8.x",
+    "eslint-config-prettier": "9.x",
     "eslint-plugin-unused-imports": "3.x",
     "next": "13.x",
     "prettier": "3.x"

--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -27,6 +27,6 @@
     "eslint-config-prettier": "8.x",
     "eslint-plugin-unused-imports": "3.x",
     "next": "13.x",
-    "prettier": "2.x"
+    "prettier": "3.x"
   }
 }

--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintlify/eslint-config-next",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Mintlify shared eslint config (next)",
   "author": "Mintlify, Inc.",
   "homepage": "https://mintlify.com/",

--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -18,8 +18,8 @@
     "publish-manual": "npm publish"
   },
   "peerDependencies": {
-    "@mintlify/eslint-config": "1.0.4",
-    "@mintlify/eslint-config-typescript": "1.0.9",
+    "@mintlify/eslint-config": "1.0.5",
+    "@mintlify/eslint-config-typescript": "1.0.10",
     "@typescript-eslint/eslint-plugin": "6.x",
     "@typescript-eslint/parser": "6.x",
     "eslint": "8.x",

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -24,6 +24,6 @@
     "eslint": "8.x",
     "eslint-config-prettier": "8.x",
     "eslint-plugin-unused-imports": "^3.x",
-    "prettier": "2.x"
+    "prettier": "3.x"
   }
 }

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintlify/eslint-config-typescript",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Mintlify shared eslint config (typescript)",
   "author": "Mintlify, Inc.",
   "homepage": "https://mintlify.com/",
@@ -18,7 +18,7 @@
     "publish-manual": "npm publish"
   },
   "peerDependencies": {
-    "@mintlify/eslint-config": "1.0.4",
+    "@mintlify/eslint-config": "1.0.5",
     "@typescript-eslint/eslint-plugin": "6.x",
     "@typescript-eslint/parser": "6.x",
     "eslint": "8.x",

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -22,7 +22,7 @@
     "@typescript-eslint/eslint-plugin": "6.x",
     "@typescript-eslint/parser": "6.x",
     "eslint": "8.x",
-    "eslint-config-prettier": "8.x",
+    "eslint-config-prettier": "9.x",
     "eslint-plugin-unused-imports": "^3.x",
     "prettier": "3.x"
   }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintlify/eslint-config",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Mintlify shared eslint config (base)",
   "author": "Mintlify, Inc.",
   "homepage": "https://mintlify.com/",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -21,6 +21,6 @@
     "eslint": "8.x",
     "eslint-config-prettier": "8.x",
     "eslint-plugin-unused-imports": "3.x",
-    "prettier": "2.x"
+    "prettier": "3.x"
   }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "eslint": "8.x",
-    "eslint-config-prettier": "8.x",
+    "eslint-config-prettier": "9.x",
     "eslint-plugin-unused-imports": "3.x",
     "prettier": "3.x"
   }


### PR DESCRIPTION
Prettier in our prettier package was bumped but prettier in our eslint packages weren't so if you bump our prettier package you get a conflict warning saying that the prettier version doesnt match what our eslint packages requested. This PR bumps the prettier version in our eslint packages.