### PR TITLE
fix: add decorators support

### DIFF
--- a/packages/prettier-config/config.js
+++ b/packages/prettier-config/config.js
@@ -11,5 +11,6 @@ module.exports = {
   bracketSameLine: false,
   plugins: ["@trivago/prettier-plugin-sort-imports", "prettier-plugin-tailwindcss"],
   importOrder: ["<THIRD_PARTY_MODULES>", "^@/(.*)$", "^[./]"],
+  importOrderParserPlugins: ["typescript", "jsx", "decorators"],
   importOrderSeparation: true
 };

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintlify/prettier-config",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Mintlify shared prettier config",
   "author": "Mintlify, Inc.",
   "homepage": "https://mintlify.com/",


### PR DESCRIPTION
Follows the advice in [this issue](https://github.com/trivago/prettier-plugin-sort-imports/issues/120#issuecomment-996555462) and adds the decorator plugin to the [importOrderParserPlugins](https://github.com/trivago/prettier-plugin-sort-imports?tab=readme-ov-file#importorderparserplugins) option